### PR TITLE
Introduce error classes to hoist all calls of process.exit()

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "ts-node src/index.ts",
     "build": "yarn clean; tsc; cp src/command.js dist/command.js",
     "clean": "rimraf ./dist; rimraf ./tsconfig.tsbuildinfo",
+    "debug": "node -r ts-node/register --inspect src/index.ts",
     "test": "tslint --project .",
     "release": "yarn test; yarn build; npm publish"
   },

--- a/src/Parser.ts
+++ b/src/Parser.ts
@@ -1,5 +1,6 @@
 import { IWorkDay, IWorkEntry } from "./types";
 import { parseDate } from "./jira/util";
+import { FormatError } from "./errors";
 
 export class Parser {
   public static parse(text: string): IWorkDay[] {
@@ -13,8 +14,7 @@ export class Parser {
       const date = parseDate(first, ["d.M.", "d.M.yy"]);
 
       if (!date) {
-        console.error(`Could not parse date ${first}`);
-        process.exit(1);
+        throw new FormatError(`Could not parse date ${first}`);
       }
 
       return {
@@ -48,12 +48,12 @@ export class Parser {
           ticketId = parts[0].replace("+", "").trim();
           const existingEntry = entries.find(e => e.ticketId === ticketId);
           if (!existingEntry) {
-            console.error(
+            throw new FormatError(
               `Missing Description for ${ticketId} on day ${startTime}`
             );
-            process.exit(1);
+          } else {
+            description = existingEntry.description;
           }
-          description = existingEntry.description;
         } else {
           ticketId = parts[0].replace("+", "").trim();
           description = parts
@@ -95,8 +95,7 @@ export class Parser {
     const time = parseDate(trimmed, ["H", "H:m"]);
 
     if (!time) {
-      console.error(`Time ${trimmed} not in right format`);
-      process.exit(1);
+      throw new FormatError(`Time ${trimmed} not in right format`);
     }
 
     return time;

--- a/src/errors/AuthenticationError.ts
+++ b/src/errors/AuthenticationError.ts
@@ -1,0 +1,21 @@
+import { AxiosError } from "axios";
+
+export class AuthenticationError extends Error {
+  public static fromAxiosError(e: AxiosError) {
+    let message = `Request Failed: ${e.message}`;
+
+    switch (true) {
+      case e.response?.data?.errorMessages?.length: {
+        const { errorMessages } = e.response?.data;
+        message = ["Login failed:", ...errorMessages].join("\n");
+        break;
+      }
+      case e.response?.headers["x-seraph-loginreason"]: {
+        message = "CAPTCHA Error: Please complete the Captcha in your Browser";
+        break;
+      }
+    }
+
+    return new AuthenticationError(message);
+  }
+}

--- a/src/errors/FormatError.ts
+++ b/src/errors/FormatError.ts
@@ -1,0 +1,1 @@
+export class FormatError extends Error {}

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,2 @@
+export * from "./AuthenticationError";
+export * from "./FormatError";

--- a/src/jira/JiraApiConnector.ts
+++ b/src/jira/JiraApiConnector.ts
@@ -15,6 +15,7 @@ import {
   IJiraWorklog
 } from "./JiraClient";
 import { getLastThursday } from "./util";
+import { AuthenticationError } from "../errors";
 
 export class JiraApiConnector implements IApiConnector {
   private client: JiraClient;
@@ -68,7 +69,11 @@ export class JiraApiConnector implements IApiConnector {
 
   public async importLogs(days: IWorkDay[]) {
     console.log("Obtaining Cookie...");
-    await this.client.obtainCookie();
+    try {
+      await this.client.obtainCookie();
+    } catch (e) {
+      throw AuthenticationError.fromAxiosError(e);
+    }
 
     const preparedEntries = this.prepareEntries(days);
 
@@ -91,6 +96,7 @@ export class JiraApiConnector implements IApiConnector {
 
   /**
    * Clears logs that were previously written and are part of the current batch
+   * @param logs
    * @param onDays
    */
   private async clearOldLogs(

--- a/src/jira/JiraClient.ts
+++ b/src/jira/JiraClient.ts
@@ -39,30 +39,15 @@ export class JiraClient {
   constructor(private host: string, private credentials: IJiraCredentials) {}
 
   public async obtainCookie() {
-    try {
-      const retVal = await axios.post(SESSION_URL(this.host), this.credentials);
-
-      if (retVal.status !== 200) {
-        throw new Error("Login failed");
-      }
-      this.cookie = `JSESSIONID=${retVal.data.session.value}`;
-    } catch (e) {
-      if (e.response.data?.errorMessages?.length) {
-        console.log("Login failed:");
-        e.response.data.errorMessages.map((m: string) => console.error(m));
-        process.exit(1);
-      }
-
-      if (e.response.headers["x-seraph-loginreason"]) {
-        console.error(
-          "CAPTCHA Error. Please complete the Captcha in your Browser"
-        );
-        process.exit(1);
-      }
-
-      console.error("Login failed");
-      process.exit(1);
-    }
+    const axiosInstance = axios.create({
+      validateStatus: status => status === 200,
+      timeout: 10000
+    });
+    const retVal = await axiosInstance.post(
+      SESSION_URL(this.host),
+      this.credentials
+    );
+    this.cookie = `JSESSIONID=${retVal.data.session.value}`;
   }
 
   public async createWorklog(


### PR DESCRIPTION
I added two new error classes `AuthenticationError` and `FormatError` to call `process.exit()` in the commander actions.